### PR TITLE
Replace `whereRaw` with `where` for LIKE statement

### DIFF
--- a/src/Driver/MySqlDiscussionTitleDriver.php
+++ b/src/Driver/MySqlDiscussionTitleDriver.php
@@ -12,8 +12,8 @@ class MySqlDiscussionTitleDriver implements DriverInterface
      */
     public function match($string)
     {
-        $discussionIds = Discussion::whereRaw("is_approved = 1 AND title LIKE '%$string%'")
-            ->orderBy('id', 'desc')
+        $discussionIds = Discussion::where("is_approved", 1)
+            ->where('title', 'like', '%' . $string . '%')
             ->limit(50)
             ->lists('id','start_post_id');
 


### PR DESCRIPTION
For SQL inject protection propose, using `whereRaw` is danger. Using `where` method with `LIKE` operation is more safe, so replace it.